### PR TITLE
Bump prometheus-cpp from v0.7.0 to v1.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,8 +334,8 @@ endif()
 #
 ExternalProject_Add(prometheus-cpp
   PREFIX prometheus-cpp
-  URL "https://github.com/jupp0r/prometheus-cpp/archive/v0.7.0.tar.gz"
-  URL_HASH SHA256=93907d937fa7eab9605cba786123d3eba4e87e3dca8ecec93ff9eae4eef8de5a
+  URL "https://github.com/jupp0r/prometheus-cpp/archive/v1.0.1.tar.gz"
+  URL_HASH SHA256=593e028d401d3298eada804d252bc38d8cab3ea1c9e88bcd72095281f85e6d16
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/prometheus-cpp/src/prometheus-cpp"
   EXCLUDE_FROM_ALL ON
   CMAKE_CACHE_ARGS


### PR DESCRIPTION
See core PR for more details: https://github.com/triton-inference-server/core/pull/115