### PR TITLE
Fix prometheus cpp inconsistent hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,8 +339,8 @@ endif()
 #
 ExternalProject_Add(prometheus-cpp
   PREFIX prometheus-cpp
-  URL "https://github.com/jupp0r/prometheus-cpp/archive/v1.0.1.tar.gz"
-  URL_HASH SHA256=593e028d401d3298eada804d252bc38d8cab3ea1c9e88bcd72095281f85e6d16
+  GIT_REPOSITORY "https://github.com/jupp0r/prometheus-cpp.git"
+  GIT_TAG "76470b3ec024c8214e1f4253fb1f4c0b28d3df94"
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/prometheus-cpp/src/prometheus-cpp"
   EXCLUDE_FROM_ALL ON
   CMAKE_CACHE_ARGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ endif()
 ExternalProject_Add(prometheus-cpp
   PREFIX prometheus-cpp
   GIT_REPOSITORY "https://github.com/jupp0r/prometheus-cpp.git"
-  GIT_TAG "76470b3ec024c8214e1f4253fb1f4c0b28d3df94"
+  GIT_TAG "v1.0.1"
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/prometheus-cpp/src/prometheus-cpp"
   EXCLUDE_FROM_ALL ON
   CMAKE_CACHE_ARGS


### PR DESCRIPTION
The hash value from GitHub .tar.gz can change, but there is no change to the release. This fix is to download the release directly from GitHub release commit, instead of from .tar.gz file.