### PR TITLE
build(API): Address API deprecation warnings.  

### DIFF
--- a/cnmem/CMakeLists.txt
+++ b/cnmem/CMakeLists.txt
@@ -30,4 +30,4 @@ set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_subdirectory(cnmem) 
+add_subdirectory(cnmem)

--- a/cnmem/CMakeLists.txt
+++ b/cnmem/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright 2015-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required(VERSION 3.17)
+project(cnmem LANGUAGES C CXX)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_subdirectory(cnmem) 

--- a/cnmem/cnmem/CMakeLists.txt
+++ b/cnmem/cnmem/CMakeLists.txt
@@ -3,16 +3,16 @@ cmake_minimum_required(VERSION 2.8.8)
 project(cnmem)
 
 # We need CUDA to build that library.
-find_package(CUDA QUIET REQUIRED)
-message(STATUS "CUDA_VERSION: ${CUDA_VERSION}")
-include_directories(${CUDA_INCLUDE_DIRS})
+find_package(CUDAToolkit QUIET REQUIRED)
+message(STATUS "CUDAToolkit_VERSION: ${CUDAToolkit_VERSION}")
+include_directories(${CUDAToolkit_INCLUDE_DIRS})
 
 # Rules to build the cnmem library.
 include_directories(include)
 add_definitions(-DCNMEM_DLLEXPORT)
 add_library(cnmem STATIC src/cnmem.cpp)
 set_target_properties(cnmem PROPERTIES VERSION 1.0.0 SOVERSION 1)
-target_link_libraries(cnmem LINK_PUBLIC ${CUDA_LIBRARIES})
+target_link_libraries(cnmem LINK_PUBLIC ${CUDAToolkit_LIBRARY_DIR})
 install(TARGETS cnmem RUNTIME DESTINATION bin ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
 install(FILES include/cnmem.h DESTINATION include)
 
@@ -33,12 +33,12 @@ if(WITH_TESTS)
   if(CMAKE_COMPILER_IS_GNUCC)
     add_definitions(-std=c++11 -DUSE_CPP_11)
   endif(CMAKE_COMPILER_IS_GNUCC)
-  target_link_libraries(cnmem_tests LINK_PUBLIC cnmem ${CUDA_LIBRARIES} ${GTEST_LIBRARIES} -lpthread)
+  target_link_libraries(cnmem_tests LINK_PUBLIC cnmem ${CUDAToolkit_LIBRARY_DIR} ${GTEST_LIBRARIES} -lpthread)
   install(TARGETS cnmem_tests RUNTIME DESTINATION bin)
 
   # Tests that launch kernels to force reading and writing to memory
   cuda_add_executable(cnmem_kernel_tests tests/cnmem_kernel_test.cu)
-  target_link_libraries(cnmem_kernel_tests cnmem ${CUDA_LIBRARIES} ${GTEST_LIBRARIES} -lpthread)
+  target_link_libraries(cnmem_kernel_tests cnmem ${CUDAToolkit_LIBRARY_DIR} ${GTEST_LIBRARIES} -lpthread)
   install(TARGETS cnmem_kernel_tests RUNTIME DESTINATION bin)
 
   # On Windows, we copy the Google test DLL to the bin folder.

--- a/cnmem/cnmem/CMakeLists.txt
+++ b/cnmem/cnmem/CMakeLists.txt
@@ -1,3 +1,28 @@
+# Copyright 2015-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # CMakeLists to build the cnmem library.
 cmake_minimum_required(VERSION 2.8.8)
 project(cnmem)

--- a/cnmem/cnmem/CMakeLists.txt
+++ b/cnmem/cnmem/CMakeLists.txt
@@ -4,6 +4,7 @@ project(cnmem)
 
 # We need CUDA to build that library.
 find_package(CUDA QUIET REQUIRED)
+message(STATUS "CUDA_VERSION: ${CUDA_VERSION}")
 include_directories(${CUDA_INCLUDE_DIRS})
 
 # Rules to build the cnmem library.
@@ -21,7 +22,7 @@ if(WITH_TESTS)
   # Get Google tests.
   find_package(GTest QUIET REQUIRED)
   include_directories(${GTEST_INCLUDE_DIRS})
-  
+
   # Build the executable.
   add_executable(cnmem_tests tests/cnmem_tests.cpp)
   if(MSVC)

--- a/cnmem/cnmem/src/cnmem.cpp
+++ b/cnmem/cnmem/src/cnmem.cpp
@@ -511,7 +511,7 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
         if (mFlags & CNMEM_FLAGS_MANAGED) {
             CNMEM_DEBUG_INFO("cudaMallocManaged(%lu)\n", size);
             CNMEM_CHECK_CUDA(cudaMallocManaged(&data, size));
-            CNMEM_CHECK_CUDA(cudaMemPrefetchAsync_v2(data, size, mDevice));
+            CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, mDevice, mStream));
         }
         else {
             CNMEM_DEBUG_INFO("cudaMalloc(%lu)\n", size);

--- a/cnmem/cnmem/src/cnmem.cpp
+++ b/cnmem/cnmem/src/cnmem.cpp
@@ -497,17 +497,19 @@ cnmemStatus_t Manager::allocate(void *&ptr, std::size_t size, bool isBlocking) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-
 cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size_t size) {
     // Reset the outputs.
     curr = prev = NULL;
 
     // Try to allocate data from the parent or the device.
     void *data = NULL;
+#define STRINGIFY_HELPER(x) #x
+#define STRINGIFY(x) STRINGIFY_HELPER(x)
 
-#if CUDA_VERSION >= 13000
-        cudaMemLocation loc;
-        loc.id = mDevice;
+#pragma message("Preprocessor value CUDART_VERSION: " STRINGIFY(CUDART_VERSION))
+#if CUDART_VERSION >= 13000
+    cudaMemLocation loc;
+    loc.id = mDevice;
 #endif
 
     if( mParent ) {
@@ -518,7 +520,7 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
             CNMEM_DEBUG_INFO("cudaMallocManaged(%lu)\n", size);
             CNMEM_CHECK_CUDA(cudaMallocManaged(&data, size));
 
-#if CUDA_VERSION >= 13000
+#if CUDART_VERSION >= 13000
             CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, loc, mDevice));
 #else
             CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, mDevice));

--- a/cnmem/cnmem/src/cnmem.cpp
+++ b/cnmem/cnmem/src/cnmem.cpp
@@ -511,7 +511,7 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
         if (mFlags & CNMEM_FLAGS_MANAGED) {
             CNMEM_DEBUG_INFO("cudaMallocManaged(%lu)\n", size);
             CNMEM_CHECK_CUDA(cudaMallocManaged(&data, size));
-            CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, mDevice));
+            CNMEM_CHECK_CUDA(cudaMemPrefetchAsync_v2(data, size, mDevice));
         }
         else {
             CNMEM_DEBUG_INFO("cudaMalloc(%lu)\n", size);

--- a/cnmem/cnmem/src/cnmem.cpp
+++ b/cnmem/cnmem/src/cnmem.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2015-2025, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/cnmem/cnmem/src/cnmem.cpp
+++ b/cnmem/cnmem/src/cnmem.cpp
@@ -71,13 +71,13 @@ extern "C" const char* cnmemGetErrorString(cnmemStatus_t status) {
 #else
 #include <execinfo.h>
 static inline void printBacktrace() {
-    void *stackBuffer[64]; 
-    int numAddresses = backtrace((void**) &stackBuffer, 64); 
-    char **addresses = backtrace_symbols(stackBuffer, numAddresses); 
-    for( int i = 0 ; i < numAddresses ; ++i ) { 
-        fprintf(stderr, "[%2d]: %s\n", i, addresses[i]); 
-    } 
-    free(addresses); 
+    void *stackBuffer[64];
+    int numAddresses = backtrace((void**) &stackBuffer, 64);
+    char **addresses = backtrace_symbols(stackBuffer, numAddresses);
+    for( int i = 0 ; i < numAddresses ; ++i ) {
+        fprintf(stderr, "[%2d]: %s\n", i, addresses[i]);
+    }
+    free(addresses);
 }
 #define CNMEM_DEBUG_ERROR(...) do { \
     fprintf(stderr, "Error at line: %d\n", __LINE__); \
@@ -108,7 +108,7 @@ static inline void printBacktrace() {
         CNMEM_DEBUG_ERROR("CNMEM_CHECK_TRUE evaluates to false\n"); \
         return error; \
     } \
-} while(0) 
+} while(0)
 
 #define CNMEM_CHECK(call) do { \
     cnmemStatus_t status = (call); \
@@ -260,7 +260,7 @@ cnmemStatus_t Mutex::unlock() const {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 class Block {
-    /// The pointer to the memory region on the device. 
+    /// The pointer to the memory region on the device.
     char *mData;
     /// The size of the memory buffer.
     std::size_t mSize;
@@ -277,12 +277,12 @@ public:
         , mNext(next)
         , mIsHead(isHead) {
     }
-    
+
     /// The data.
     inline const char* getData() const { return mData; }
     /// The data (mutable).
     inline char* getData() { return mData; }
-    
+
     /// The size of the block.
     inline std::size_t getSize() const { return mSize; }
 
@@ -290,7 +290,7 @@ public:
     inline const Block* getNext() const { return mNext; }
     /// The next block in the linked list (mutable).
     inline Block* getNext() { return mNext; }
-    
+
     /// Is it a head block.
     inline bool isHead() const { return mIsHead; }
 
@@ -348,17 +348,17 @@ public:
     cnmemStatus_t printMemoryState(FILE *file) const;
 
     /// The amount of used memory.
-    inline cnmemStatus_t getUsedMemoryUnsafe(std::size_t &usedMemory) const { 
-        return getMemoryUnsafe(usedMemory, mUsedBlocks); 
+    inline cnmemStatus_t getUsedMemoryUnsafe(std::size_t &usedMemory) const {
+        return getMemoryUnsafe(usedMemory, mUsedBlocks);
     }
     /// The amount of used memory.
-    inline cnmemStatus_t getFreeMemoryUnsafe(std::size_t &freeMemory) const { 
-        return getMemoryUnsafe(freeMemory, mFreeBlocks); 
+    inline cnmemStatus_t getFreeMemoryUnsafe(std::size_t &freeMemory) const {
+        return getMemoryUnsafe(freeMemory, mFreeBlocks);
     }
-    
-    /// Get a specific child based on the stream id. 
+
+    /// Get a specific child based on the stream id.
     cnmemStatus_t getChildFromStream(Manager *&manager, cudaStream_t stream) const;
-    /// Get a specific child based on the stream id. 
+    /// Get a specific child based on the stream id.
     cnmemStatus_t getChild(Manager *&manager, std::size_t i) const;
     /// Add a new child.
     cnmemStatus_t addChild(Manager *manager);
@@ -375,14 +375,14 @@ public:
     inline std::size_t getSize() const { return mSize; }
     /// The CUDA stream.
     inline cudaStream_t getStream() const { return mStream; }
-    
+
     /// Define the parent.
     inline void setParent(Manager *parent) { mParent = parent; }
     /// Define the device.
     inline void setDevice(int device) { mDevice = device; }
     /// Define the stream.
-    inline cnmemStatus_t setStream(cudaStream_t stream) { 
-        mStream = stream; 
+    inline cnmemStatus_t setStream(cudaStream_t stream) {
+        mStream = stream;
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
         mIsStreamBlocking = false;
 #elif CUDART_VERSION < 5050
@@ -396,7 +396,7 @@ public:
     }
     /// Define the flags.
     inline void setFlags(unsigned flags) { mFlags = flags; }
-    
+
 private:
     /// The member functions below which are marked "Unsafe" are not thread-safe when called on a
     /// same Manager object. Make sure they are called by a single thread in that case.
@@ -409,12 +409,12 @@ private:
     cnmemStatus_t findBestBlockUnsafe(Block *&curr, Block *&prev, std::size_t size);
     /// Extract a node from the list of free blocks.
     cnmemStatus_t extractBlockUnsafe(Block *curr, Block *prev, std::size_t size, bool stolen);
-    
+
     /// Give a free block from that manager.
     cnmemStatus_t giveBlockUnsafe(void *&data, std::size_t &dataSize, std::size_t size);
     /// Steal a block from another manager.
     cnmemStatus_t stealBlockUnsafe(void *&data, std::size_t &dataSize, std::size_t size);
-    
+
     /// The memory consumption of a list.
     cnmemStatus_t getMemoryUnsafe(std::size_t &memSize, const Block *head) const;
     /// Print an internal linked list.
@@ -471,11 +471,11 @@ cnmemStatus_t Manager::allocate(void *&ptr, std::size_t size, bool isBlocking) {
     Block *best = NULL, *prev = NULL;
     CNMEM_CHECK_OR_UNLOCK(findBestBlockUnsafe(best, prev, size), mMutex);
 
-    // If there's no block left in the list of free blocks (with a sufficient size). Request a new block. 
+    // If there's no block left in the list of free blocks (with a sufficient size). Request a new block.
     if( best == NULL && !(mFlags & CNMEM_FLAGS_CANNOT_GROW) ) {
         CNMEM_CHECK_OR_UNLOCK(allocateBlockUnsafe(best, prev, size), mMutex);
     }
-    
+
     // Make sure we do have a block or quit.
     if( !best ) {
         ptr = NULL;
@@ -504,8 +504,10 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
 
     // Try to allocate data from the parent or the device.
     void *data = NULL;
-    cudaMemLocation loc;
-    loc.id = mDevice;
+    if (CUDA_VERSION >= 13000) {
+        cudaMemLocation loc;
+        loc.id = mDevice;
+    }
     if( mParent ) {
         CNMEM_CHECK(mParent->allocate(data, size, mIsStreamBlocking));
     }
@@ -513,7 +515,11 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
         if (mFlags & CNMEM_FLAGS_MANAGED) {
             CNMEM_DEBUG_INFO("cudaMallocManaged(%lu)\n", size);
             CNMEM_CHECK_CUDA(cudaMallocManaged(&data, size));
-            CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, loc, mDevice));
+            if (CUDA_VERSION >= 13000) {
+                CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, loc, mDevice));
+            } else {
+                CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, mDevice));
+            }
         }
         else {
             CNMEM_DEBUG_INFO("cudaMalloc(%lu)\n", size);
@@ -521,7 +527,7 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
         }
         CNMEM_DEBUG_INFO(">> returned address=0x%016lx\n", (size_t) data);
     }
-    
+
     // If it failed, there's an unexpected issue.
     CNMEM_ASSERT(data);
 
@@ -561,7 +567,7 @@ cnmemStatus_t Manager::extractBlockUnsafe(Block *curr, Block *prev, std::size_t 
         next = newBlock;
         curr->setSize(size);
     }
-    
+
     // Redo the "branching" in the nodes.
     if( prev ) {
         prev->setNext(next);
@@ -648,14 +654,14 @@ cnmemStatus_t Manager::getNumChildren(std::size_t &numChildren) const {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 cnmemStatus_t Manager::giveBlockUnsafe(void *&blockData, std::size_t &blockSize, std::size_t size) {
-    // Make sure the block is not in use any more. It could be too coarse grain and we may change 
+    // Make sure the block is not in use any more. It could be too coarse grain and we may change
     // it in the future.
     CNMEM_CHECK_CUDA(cudaStreamSynchronize(mStream));
-    
+
     // Init the returned values to 0.
     blockData = NULL;
     blockSize = 0;
-    
+
     // Find the best node to steal and reserve it.
     Block *best = NULL, *prev = NULL;
     CNMEM_CHECK(findBestBlockUnsafe(best, prev, size));
@@ -665,7 +671,7 @@ cnmemStatus_t Manager::giveBlockUnsafe(void *&blockData, std::size_t &blockSize,
     CNMEM_CHECK(extractBlockUnsafe(best, prev, size, true));
     blockData = best->getData();
     blockSize = best->getSize();
-    
+
     // Release the memory used by that block.
     delete best;
     return CNMEM_STATUS_SUCCESS;
@@ -681,13 +687,13 @@ cnmemStatus_t Manager::printListUnsafe(FILE *file, const char *name, const Block
 #ifdef CNMEM_BUILD_WITH_32_BIT_POINTERS
     fprintf(file, "| list=\"%s\", size=%u\n", name, size);
     for( Block *curr = (Block*) head ; curr ; curr = curr->getNext() ) {
-        fprintf(file, "| | node=0x%08x, data=0x%08x, size=%u, next=0x%08x, head=%2u\n", 
+        fprintf(file, "| | node=0x%08x, data=0x%08x, size=%u, next=0x%08x, head=%2u\n",
 #else
     fprintf(file, "| list=\"%s\", size=%lu\n", name, size);
     for( Block *curr = (Block*) head ; curr ; curr = curr->getNext() ) {
-        fprintf(file, "| | node=0x%016lx, data=0x%016lx, size=%lu, next=0x%016lx, head=%2lu\n", 
+        fprintf(file, "| | node=0x%016lx, data=0x%016lx, size=%lu, next=0x%016lx, head=%2lu\n",
 #endif
-            (std::size_t) curr, 
+            (std::size_t) curr,
             (std::size_t) curr->getData(),
             (std::size_t) curr->getSize(),
             (std::size_t) curr->getNext(),
@@ -707,12 +713,12 @@ cnmemStatus_t Manager::printMemoryState(FILE *file) const {
     CNMEM_CHECK_OR_UNLOCK(getFreeMemoryUnsafe(freeMemory), mMutex);
 
 #ifdef CNMEM_BUILD_WITH_32_BIT_POINTERS
-    fprintf(file, ">> [%s] device=%d, stream=0x%08x, used=%uB, free=%uB\n", 
+    fprintf(file, ">> [%s] device=%d, stream=0x%08x, used=%uB, free=%uB\n",
 #else
-    fprintf(file, ">> [%s] device=%d, stream=0x%016lx, used=%luB, free=%luB\n", 
+    fprintf(file, ">> [%s] device=%d, stream=0x%016lx, used=%luB, free=%luB\n",
 #endif
             mParent ? "child" : "root",
-            mDevice, 
+            mDevice,
             streamCode,
             usedMemory,
             freeMemory);
@@ -734,16 +740,16 @@ cnmemStatus_t Manager::release(void *ptr) {
     if( ptr == NULL ) {
         return CNMEM_STATUS_SUCCESS;
     }
-        
+
     // Lock to make sure only one thread execute that fragment of code.
     CNMEM_CHECK(mMutex.lock());
-    
+
     // Find the node in the list of used blocks.
     Block *curr = mUsedBlocks, *prev = NULL;
     for( ; curr && curr->getData() != ptr ; curr = curr->getNext() ) {
         prev = curr;
     }
-    
+
     // Make sure we have found a node.
     if( curr == NULL ) {
         CNMEM_CHECK(mMutex.unlock());
@@ -799,7 +805,7 @@ cnmemStatus_t Manager::releaseAllUnsafe() {
 cnmemStatus_t Manager::releaseBlockUnsafe(Block *curr, Block *prev) {
     // The current node cannot be NULL!
     CNMEM_ASSERT(curr != NULL);
-    
+
     // Change the connection of the node.
     if( prev ) {
         prev->setNext(curr->getNext());
@@ -807,17 +813,17 @@ cnmemStatus_t Manager::releaseBlockUnsafe(Block *curr, Block *prev) {
     else {
         mUsedBlocks = curr->getNext();
     }
-        
+
     // Find the location where this block should be added to the free list.
     prev = NULL;
     Block *iter = mFreeBlocks;
     for( ; iter && iter->getData() < curr->getData() ; iter = iter->getNext() ) {
         prev = iter;
     }
-    
+
     // Keep track of the successor of pred. We may lose track of it in the following "else".
     Block *next = prev ? prev->getNext() : mFreeBlocks;
-    
+
     // We first check if we can merge the block with its predecessor in the list and curr can be merged.
     if( prev && prev->getData() + prev->getSize() == curr->getData() && !curr->isHead() ) {
         prev->setSize(prev->getSize() + curr->getSize());
@@ -830,7 +836,7 @@ cnmemStatus_t Manager::releaseBlockUnsafe(Block *curr, Block *prev) {
     else {
         mFreeBlocks = curr;
     }
-    
+
     // Check if we can merge curr and next. We can't merge over "cudaMalloc" boundaries.
     if( next && curr->getData() + curr->getSize() == next->getData() && !next->isHead() ) {
         curr->setSize(curr->getSize() + next->getSize());
@@ -871,7 +877,7 @@ cnmemStatus_t Manager::stealUnsafe(void *&stolen, std::size_t size) {
     else if( mParent ) {
         CNMEM_CHECK(mParent->stealBlockUnsafe(data, dataSize, size));
     }
-    
+
     // Make sure we do have a block of memory or quit.
     if( !data ) {
         stolen = NULL;
@@ -900,22 +906,22 @@ cnmemStatus_t Manager::stealBlockUnsafe(void *&data, std::size_t &dataSize, ::si
             break;
         }
     }
-        
+
     // If no memory space found, simply return NULL. We have failed to allocate. Quit miserably.
     if( !data ) {
         return CNMEM_STATUS_OUT_OF_MEMORY;
     }
 
-    // We have got a node from a children. We need to update our "used" list before we can do 
+    // We have got a node from a children. We need to update our "used" list before we can do
     // anything with it.
     Block *curr = mUsedBlocks, *prev = NULL;
-    for( ; curr ; curr = curr->getNext() ) { 
+    for( ; curr ; curr = curr->getNext() ) {
         if( curr->getData() <= data && data < curr->getData()+curr->getSize() ) {
             break;
         }
         prev = curr;
     }
-    
+
     // Curr points to the node which contains that memory region.
     CNMEM_ASSERT(curr);
 
@@ -923,17 +929,17 @@ cnmemStatus_t Manager::stealBlockUnsafe(void *&data, std::size_t &dataSize, ::si
     if( curr->getData() == data && curr->getSize() == dataSize ) {
         return CNMEM_STATUS_SUCCESS;
     }
-    
+
     // Track the blocks before and after curr.
     Block *next = curr->getNext();
-    
+
     // We may have up to 3 blocks.
     std::size_t sizeBefore = (std::size_t) ((char*) data - curr->getData());
     std::size_t sizeAfter = (curr->getSize() - sizeBefore - dataSize);
 
     // The resulting block.
     Block *result = curr;
-    
+
     // If we have no space between curr->getData and block->getData.
     if( sizeBefore == 0 ) {
         curr->setSize(dataSize);
@@ -947,10 +953,10 @@ cnmemStatus_t Manager::stealBlockUnsafe(void *&data, std::size_t &dataSize, ::si
         curr->setNext(block);
         curr = block;
         data = (char*) data + dataSize;
-        dataSize = sizeAfter; 
+        dataSize = sizeAfter;
         result = block;
     }
-    
+
     // We have space at the end so we may need to add a new node.
     if( sizeAfter > 0 ) {
         Block *block = new Block(curr->getData() + curr->getSize(), sizeAfter, next, false);
@@ -1007,7 +1013,7 @@ int Context::sCtxCheck;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-Context::~Context() { 
+Context::~Context() {
     int oldDevice;
     cudaGetDevice(&oldDevice);
     for( std::size_t i = 0 ; i < mManagers.size() ; ++i ) {
@@ -1038,9 +1044,9 @@ Context* Context::get() {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-cnmemStatus_t Context::retain() { 
+cnmemStatus_t Context::retain() {
     CNMEM_CHECK(sCtx->mMutex.lock());
-    sCtx->mRefCount++; 
+    sCtx->mRefCount++;
     CNMEM_CHECK(sCtx->mMutex.unlock());
     return CNMEM_STATUS_SUCCESS;
 }
@@ -1073,7 +1079,7 @@ extern "C" {
 cnmemStatus_t cnmemInit(int numDevices, const cnmemDevice_t *devices, unsigned flags) {
     // Make sure we have at least one device declared.
     CNMEM_CHECK_TRUE(numDevices > 0, CNMEM_STATUS_INVALID_ARGUMENT);
-    
+
     // Find the largest ID of the device.
     int maxDevice = 0;
     for( int i = 0 ; i < numDevices ; ++i ) {
@@ -1085,7 +1091,7 @@ cnmemStatus_t cnmemInit(int numDevices, const cnmemDevice_t *devices, unsigned f
     // Create the global context.
     cnmem::Context::create();
     cnmem::Context *ctx = cnmem::Context::get();
-        
+
     // Allocate enough managers.
     CNMEM_CHECK_TRUE(maxDevice >= 0, CNMEM_STATUS_INVALID_ARGUMENT);
     std::vector<cnmem::Manager> &managers = ctx->getManagers();
@@ -1104,14 +1110,14 @@ cnmemStatus_t cnmemInit(int numDevices, const cnmemDevice_t *devices, unsigned f
         }
         CNMEM_CHECK_TRUE(
             size > 0 && size < props.totalGlobalMem, CNMEM_STATUS_INVALID_ARGUMENT);
-        
+
         cnmem::Manager &manager = ctx->getManager(devices[i].device);
         manager.setDevice(devices[i].device);
         manager.setFlags(flags);
-        
+
         size = cnmem::ceilInt(size, CNMEM_GRANULARITY);
         CNMEM_CHECK(manager.reserve(size));
-        
+
         for( int j = 0 ; j < devices[i].numStreams ; ++j ) {
             cnmem::Manager *child = new cnmem::Manager;
             child->setParent(&manager);
@@ -1157,7 +1163,7 @@ cnmemStatus_t cnmemRelease() {
 cnmemStatus_t cnmemRegisterStream(cudaStream_t stream) {
     CNMEM_CHECK_TRUE(cnmem::Context::check(), CNMEM_STATUS_NOT_INITIALIZED);
     CNMEM_CHECK_TRUE(stream, CNMEM_STATUS_INVALID_ARGUMENT);
-    
+
     int device;
     CNMEM_CHECK_CUDA(cudaGetDevice(&device));
 
@@ -1184,7 +1190,7 @@ cnmemStatus_t cnmemMalloc(void **ptr, std::size_t size, cudaStream_t stream) {
         return CNMEM_STATUS_SUCCESS;
     }
     CNMEM_CHECK_TRUE(ptr,  CNMEM_STATUS_INVALID_ARGUMENT);
-    
+
     int device;
     CNMEM_CHECK_CUDA(cudaGetDevice(&device));
 
@@ -1194,11 +1200,11 @@ cnmemStatus_t cnmemMalloc(void **ptr, std::size_t size, cudaStream_t stream) {
         CNMEM_CHECK(root.getChildFromStream(manager, stream));
     }
     CNMEM_ASSERT(manager);
-    
+
     size = cnmem::ceilInt(size, CNMEM_GRANULARITY);
     cnmemStatus_t result = manager->allocate(ptr[0], size);
 
-    // We failed to allocate but there might still be a buffer available in another manager. Try to 
+    // We failed to allocate but there might still be a buffer available in another manager. Try to
     // steal it.
     if( result == CNMEM_STATUS_OUT_OF_MEMORY ) {
 
@@ -1235,7 +1241,7 @@ cnmemStatus_t cnmemMalloc(void **ptr, std::size_t size, cudaStream_t stream) {
         }
         for( std::size_t i = 0 ; i < numLocked ; ++i ) {
             cnmemStatus_t lockStatus = mutexes[i]->unlock();
-            if( lockStatus != CNMEM_STATUS_SUCCESS ) { 
+            if( lockStatus != CNMEM_STATUS_SUCCESS ) {
                 // Starting from now we are panicking!!! One lock failed to be released, we try
                 // we others. We could also give up because we are already screwed. I don't know
                 // what's best! Comment are welcome.
@@ -1305,10 +1311,9 @@ cnmemStatus_t cnmemPrintMemoryState(FILE *file, cudaStream_t stream) {
         CNMEM_CHECK(root.getChildFromStream(manager, stream));
     }
     CNMEM_ASSERT(manager);
-    return manager->printMemoryState(file); 
+    return manager->printMemoryState(file);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 } // extern "C"
-

--- a/cnmem/cnmem/src/cnmem.cpp
+++ b/cnmem/cnmem/src/cnmem.cpp
@@ -504,6 +504,8 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
 
     // Try to allocate data from the parent or the device.
     void *data = NULL;
+    cudaMemLocation loc;
+    loc.id = mDevice;
     if( mParent ) {
         CNMEM_CHECK(mParent->allocate(data, size, mIsStreamBlocking));
     }
@@ -511,7 +513,7 @@ cnmemStatus_t Manager::allocateBlockUnsafe(Block *&curr, Block *&prev, std::size
         if (mFlags & CNMEM_FLAGS_MANAGED) {
             CNMEM_DEBUG_INFO("cudaMallocManaged(%lu)\n", size);
             CNMEM_CHECK_CUDA(cudaMallocManaged(&data, size));
-            CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, mDevice, mStream));
+            CNMEM_CHECK_CUDA(cudaMemPrefetchAsync(data, size, loc, mDevice));
         }
         else {
             CNMEM_DEBUG_INFO("cudaMalloc(%lu)\n", size);


### PR DESCRIPTION
* Addressing API changes that had place according to:  https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY.html

* Switching to [`FindCUDAToolkit`](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html) because [`FindCUDA`](https://cmake.org/cmake/help/latest/module/FindCUDA.html) been deprecated long time ago

