### PR TITLE
build(libevhtp): support Conan CMakeDeps imported targets

### DIFF
--- a/libevhtp/libevhtp/CMakeLists.txt
+++ b/libevhtp/libevhtp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31.8)
+cmake_minimum_required(VERSION 3.10)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -60,8 +60,13 @@ set(LIBEVHTP_SOURCE_FILES
     triton_timestamp.cc)
 
 find_package(Libevent REQUIRED)
-list(APPEND LIBEVHTP_EXTERNAL_LIBS ${LIBEVENT_LIBRARIES})
-list(APPEND LIBEVHTP_EXTERNAL_INCLUDES ${LIBEVENT_INCLUDE_DIRS})
+if(TARGET libevent::libevent)
+    # Conan / modern cmake: include dirs propagate via INTERFACE
+    list(APPEND LIBEVHTP_EXTERNAL_LIBS libevent::libevent)
+else()
+    list(APPEND LIBEVHTP_EXTERNAL_LIBS ${LIBEVENT_LIBRARIES})
+    list(APPEND LIBEVHTP_EXTERNAL_INCLUDES ${LIBEVENT_INCLUDE_DIRS})
+endif()
 list(APPEND package_deps Libevent)
 
 set(evhtp_dir_headers


### PR DESCRIPTION
<sup>
Resolves: TRI-122<br/>
triton-inference-server/backend#123<br/>
triton-inference-server/common#154<br/>
triton-inference-server/core#490<br/>
triton-inference-server/server#8734
</sup>

## Description

Updates the libevhtp CMakeLists.txt to support Conan CMakeDeps-generated imported targets, enabling proper integration with the new Conan 2 + CMakePresets build system adopted across the Triton repositories.

## Changes

- build(libevhtp): support Conan CMakeDeps imported targets

## Affected Files

- libevhtp/libevhtp/CMakeLists.txt