### PR TITLE
feat: Add `chunk_count` field to struct `evhtp_request`

### DIFF
--- a/libevhtp/libevhtp/include/evhtp/evhtp.h
+++ b/libevhtp/libevhtp/include/evhtp/evhtp.h
@@ -417,6 +417,7 @@ struct evhtp_request {
     evhtp_proto          proto;         /**< HTTP protocol used */
     htp_method           method;        /**< HTTP method used */
     evhtp_res            status;        /**< The HTTP response code or other error conditions */
+    size_t               chunk_count;   /**< number of chunks received so far */
     #define EVHTP_REQ_FLAG_KEEPALIVE (1 << 1)
     #define EVHTP_REQ_FLAG_FINISHED  (1 << 2)
     #define EVHTP_REQ_FLAG_CHUNKED   (1 << 3)


### PR DESCRIPTION
  Description                                                                                                                                                       
                                                                                                                                                                    
  Adds a new size_t chunk_count field to the evhtp_request struct in libevhtp to track the number of chunks received so far on a chunked HTTP request.              
                                                                                                                                                                    
  Why                                                                                                                                                               
                                                                                                                                                                    
  Required by https://github.com/triton-inference-server/server/pull/8770, which caps the chunked HTTP request chunk count at 65,536 to prevent a memory-exhaustion vector where an attacker sends many tiny chunks that libevhtp accumulates into its buffer. The server-side fix needs a per-request counter exposed on the request struct so its evhtp connection hooks can increment and inspect it.                                                     
                                                                                                                                                                  
  Implementation Notes                                                                                                                                              
   
  - Single-line addition to libevhtp/libevhtp/include/evhtp/evhtp.h.                                                                                                
  - No initialization change needed — evhtp_request is allocated via calloc in evhtp.c (lines 1274–1276), so the new field is zeroed automatically.
  - Counter is incremented/checked by the server hooks added in server#8770; it resets per request, so keepalive connection reuse is unaffected. 