### PR TITLE
[r26.07] maint: Update GRPC version to 1.18.1 (#76)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -113,7 +113,7 @@ ExternalProject_Add(curl
 ExternalProject_Add(grpc-repo
   PREFIX grpc-repo
   GIT_REPOSITORY "https://github.com/grpc/grpc.git"
-  GIT_TAG "v1.54.3"
+  GIT_TAG "v1.81.1"
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/grpc-repo/src/grpc"
   EXCLUDE_FROM_ALL ON
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
#### What does the PR do?
Cherry-pick of #76 onto `r26.07` — maint: Update GRPC version to 1.18.1. Backport of the coordinated `grpcio` dependency update. Clean cherry-pick, no conflicts.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field (`cherry-pick`)
- [x] Verified copyright is correct on all changed files.
- [x] All template sections are filled out.

#### Commit Type:
Cherry-pick — preserves the original commit type from #76.

#### Related PRs:
- triton-inference-server/server#8887
- triton-inference-server/client#907
- triton-inference-server/model_analyzer#1031
- triton-inference-server/python_backend#448

#### Where should the reviewer start?
Changed file(s): `CMakeLists.txt`. This is a direct cherry-pick of the already-reviewed #76; the diff is identical.

#### Test plan:
Verified via existing CI on `r26.07`.
- CI Pipeline ID: N/A (clean cherry-pick of #76)

#### Caveats:
None — clean cherry-pick, no conflicts.

#### Background
Backporting the `main` `grpcio` dependency update to the `r26.07` release branch.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: TRI-836
